### PR TITLE
[#20] Fix bugs in GitHub API query functions

### DIFF
--- a/src/IssueWanted/Search.hs
+++ b/src/IssueWanted/Search.hs
@@ -24,4 +24,4 @@ fetchHelpWanted = searchIssues "language:haskell label:\"help wanted\""
 
 -- | Fetch all issues with Haskell language and label "good-first-issue"
 fetchGoodFirstIssue :: IO (Either Error (SearchResult Issue))
-fetchGoodFirstIssue = searchIssues "language:haskell label:good-first-issue"
+fetchGoodFirstIssue = searchIssues "language:haskell label:\"good first issue\""

--- a/src/IssueWanted/Search.hs
+++ b/src/IssueWanted/Search.hs
@@ -20,7 +20,7 @@ fetchHaskellReposGFI = searchRepos "language:haskell good-first-issues:>0"
 
 -- | Fetch all issues with Haskell language and label "help-wanted"
 fetchHelpWanted :: IO (Either Error (SearchResult Issue))
-fetchHelpWanted = searchIssues "language:haskell label:help-wanted"
+fetchHelpWanted = searchIssues "language:haskell label:\"help wanted\""
 
 -- | Fetch all issues with Haskell language and label "good-first-issue"
 fetchGoodFirstIssue :: IO (Either Error (SearchResult Issue))


### PR DESCRIPTION
I think I have fixed the GitHub API query functions. I have changed the query strings passed into the `searchIssues` functions to the correct ones. Now, instead of just returning 8 results each, they both seem to return the correct amount of results. I have tested the query strings using curl and Postman.