### PR TITLE
[#14] Change module prefix to IW

### DIFF
--- a/issue-wanted.cabal
+++ b/issue-wanted.cabal
@@ -19,8 +19,8 @@ tested-with:         GHC == 8.4.3
 library
   hs-source-dirs:      src
   exposed-modules:     Prelude
-                       IssueWanted
-                         IssueWanted.Search
+                       IW
+                       IW.Search
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/src/IW.hs
+++ b/src/IW.hs
@@ -1,0 +1,2 @@
+module IW where
+

--- a/src/IW/Search.hs
+++ b/src/IW/Search.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module IssueWanted.Search where
+module IW.Search where
 
 import GitHub (Error, Repo, SearchResult, Issue)
 import GitHub.Endpoints.Search (searchRepos, searchIssues)

--- a/src/IssueWanted.hs
+++ b/src/IssueWanted.hs
@@ -1,2 +1,0 @@
-module IssueWanted where
-


### PR DESCRIPTION
Resolves #14 

In order to change the module names and get the project to build I
also needed to rename the exposed-modules in the issue-wanted.cabal
file.