### PR TITLE
Try to speedup CI a little bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
           key: stack-{{ checksum "stack.yaml" }}
       - run: curl https://raw.githubusercontent.com/kowainik/relude/55968311244690f5cc8b4484a37a63d988ea2ec4/.hlint.yaml -o .hlint-relude.yaml
       - run: curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -h .hlint-relude.yaml .
-      - run: stack build -j1
-      - run: stack test
+      - run: stack build -j1 --fast --test --no-run-tests
+      - run: stack test --fast
       - save_cache:
           key: stack-{{ checksum "stack.yaml" }}
           paths:


### PR DESCRIPTION
I noticed that modules in `issue-wanted` are built twice on CI. This is an attempt to improve the situtation.