### PR TITLE
[#144] Update resolver to lts-14.5

### DIFF
--- a/issue-wanted.cabal
+++ b/issue-wanted.cabal
@@ -117,7 +117,7 @@ library
                      , lens ^>= 4.17
                      , mtl ^>= 2.2.2
                      , postgresql-simple ^>= 0.6.1
-                     , postgresql-simple-named ^>= 0.0
+                     , postgresql-simple-named ^>= 0.0.2
                      , random ^>= 1.1
                      , resource-pool
                      , servant ^>= 0.16

--- a/issue-wanted.cabal
+++ b/issue-wanted.cabal
@@ -117,7 +117,7 @@ library
                      , lens ^>= 4.17
                      , mtl ^>= 2.2.2
                      , postgresql-simple ^>= 0.6.1
-                     , postgresql-simple-named ^>= 0.0.2
+                     , postgresql-simple-named ^>= 0.0.2.0
                      , random ^>= 1.1
                      , resource-pool
                      , servant ^>= 0.16

--- a/issue-wanted.cabal
+++ b/issue-wanted.cabal
@@ -111,20 +111,20 @@ library
                      , elm-street ^>= 0.0.1
                      , github == 0.22
                      , http-api-data ^>= 0.4
-                     , http-client ^>= 0.5.14
+                     , http-client ^>= 0.6
                      , http-client-tls ^>= 0.3.5.3
                      , http-types ^>= 0.12
                      , lens ^>= 4.17
                      , mtl ^>= 2.2.2
                      , postgresql-simple ^>= 0.6.1
-                     , postgresql-simple-named ^>= 0.0.0.0
+                     , postgresql-simple-named ^>= 0.0
                      , random ^>= 1.1
                      , resource-pool
                      , servant ^>= 0.16
                      , servant-server ^>= 0.16
                      , text
                      , time >= 1.8 && < 1.10
-                     , tomland ^>= 1.0.0
+                     , tomland ^>= 1.1
                      , unliftio ^>= 0.2.12
                      , unliftio-core ^>= 0.1.2.0
                      , unordered-containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,29 +1,9 @@
-resolver: lts-13.26
+resolver: lts-14.5
 
 extra-deps:
-  - relude-0.5.0
-
-  # logging
-  - co-log-0.3.0.0
-  - ansi-terminal-0.9       # for co-log
-  - chronos-1.0.5           # for co-log
-  - co-log-core-0.2.0.0     # for co-log
-  - torsor-0.1              # for co-log
-  - typerep-map-0.3.2       # for co-log
+  - postgresql-simple-named-0.0.2.0
 
   # github
   - github-0.22
   - binary-instances-1
   - binary-orphans-1.0.1
-  - time-compat-1.9.2.2
-
-  # testing
-  - hedgehog-1.0
-
-  - elm-street-0.0.1
-  - postgresql-simple-named-0.0.0.0
-  - servant-0.16.0.1
-  - servant-server-0.16
-  - tomland-1.0.0
-  - unliftio-0.2.12
-  - unliftio-core-0.1.2.0


### PR DESCRIPTION
Resolves #144.

Updates constraints for the following packages to:

- http-client ^>= 0.6
- postgresql-simple-named ^>= 0.0
- tomland ^>= 1.1

Removes all extra-deps from stack.yaml that are present in lts-14.5.

Updates postgresql-simple-named from 0.0.0.0 to 0.0.2.0 and releases its constraint to `^>= 0.0`.

This assumes that all these packages use the PVP.